### PR TITLE
Fix check-in and check-out trait methods. Closes #33

### DIFF
--- a/src/drive/mod.rs
+++ b/src/drive/mod.rs
@@ -26,7 +26,7 @@ pub use crate::drive::driveaction::{DownloadFormat, DriveEvent};
 pub use crate::drive::driveresource::DriveResource;
 pub use crate::drive::driveresource::ResourceBuilder;
 pub use crate::drive::endpoint::{DriveEndPoint, EP};
-pub use crate::drive::item::Item;
+pub use crate::drive::item::{Item, ItemResponse};
 pub use crate::drive::pathbuilder::PathBuilder;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ pub mod prelude {
     pub use crate::drive::DriveResource;
     pub use crate::drive::DriveVersion;
     pub use crate::drive::Item;
+    pub use crate::drive::ItemResponse;
     pub use crate::drive::ItemResult;
     pub use crate::drive::PathBuilder;
     pub use crate::drive::ResourceBuilder;


### PR DESCRIPTION
Changes the method fields to accept the item and drive id.